### PR TITLE
Limit the height to avoid accessing over the field

### DIFF
--- a/fumen-canvas.js
+++ b/fumen-canvas.js
@@ -105,6 +105,7 @@ function drawFumens(fumenPages, tilesize, numrows, start, end, transparent) {
         }
         numrows+=2
     }
+    numrows = Math.min(23, numrows);
     const width = tilesize*10;
     const height = numrows*tilesize;
     const canvas = createCanvas(width, height)


### PR DESCRIPTION
If there are blocks at the top of the field, the height will be set to more than 24. As a result, `field.at()` will return an error.

## Log

command: `node fumen-canvas.js gif v115@vhAVnl pc.gif` ([fumen](http://harddrop.com/fumen/?v115@vhAVnl))
output:
```
/fumen-canvas-main/node_modules/yargs/build/index.cjs:2772
                throw err;
                ^

Error: Unknown piece: undefined
    at Object.parsePieceName (/fumen-canvas-main/node_modules/tetris-fumen/lib/defines.js:40:11)
    at Field.at (/fumen-canvas-main/node_modules/tetris-fumen/lib/field.js:76:26)
    at draw (/fumen-canvas-main/fumen-canvas.js:56:22)
    at drawFumens (/fumen-canvas-main/fumen-canvas.js:121:26)
    ~~~
```